### PR TITLE
Rsk 4.8.2

### DIFF
--- a/web3/middleware/pythonic.py
+++ b/web3/middleware/pythonic.py
@@ -65,6 +65,10 @@ is_not_null = complement(is_null)
 
 @curry
 def to_hexbytes(num_bytes, val, variable_length=False):
+    # If value is none it cannot be converted, but, on RSK there are situations where value can be null.
+    # For example, v,r,s values of Remasc transactions. TODO
+    if val is None:
+        val = 1
     if isinstance(val, (str, int, bytes)):
         result = HexBytes(val)
     else:

--- a/web3/utils/formatters.py
+++ b/web3/utils/formatters.py
@@ -1,3 +1,6 @@
+import json
+
+
 from collections import (
     Iterable,
     Mapping,
@@ -27,6 +30,8 @@ def hex_to_integer(value):
 
 
 integer_to_hex = hex
+
+
 
 
 @curry
@@ -63,6 +68,8 @@ def apply_formatter_if(condition, formatter, value):
 @curry
 @to_dict
 def apply_formatters_to_dict(formatters, value):
+    if isinstance(value, str):
+        value = json.loads(value)
     for key, item in value.items():
         if key in formatters:
             try:

--- a/web3/utils/formatters.py
+++ b/web3/utils/formatters.py
@@ -21,6 +21,7 @@ from web3.utils.toolz import (
 )
 
 
+
 def hex_to_integer(value):
     return int(value, 16)
 


### PR DESCRIPTION
### What was wrong?

a) RSK returns a string instead of an object for txpool_inspect, so, formatters fails
b) RSK sends remasc transactions without v,r,s values so pyhotinc fails

### How was it fixed?

Just workarrounds for now.

a) String to Json
b) Arbitrary value when null

