### PR TITLE
 Bug fix/rlp 1097/batching get logs

### DIFF
--- a/web3/eth.py
+++ b/web3/eth.py
@@ -66,7 +66,8 @@ CONFIRMATION_BLOCKS: int = 50
 
 logger = logging.getLogger(__name__)
 
-class EthGetLogsCachedValue():
+
+class EthGetLogsCachedValue:
 
     def __init__(self, address, topics, from_block, to_block, logs):
         self.address = address
@@ -81,45 +82,37 @@ class EthGetLogsCachedValue():
             # this is needed since rskj sometimes provide events without blockNumber
             # (that's something that sometimes happens but not always, seems to be a bug on the core)
             log_block_number = log['blockNumber'] if "blockNumber" in log else None
-            if log_block_number and log_block_number >= from_block and log_block_number <= to_block:
+            if log_block_number and from_block <= log_block_number <= to_block:
                 logs.append(log)
         logger.debug(f"Getting logs from cached value from block {from_block} to block {to_block} -> logs {logs}")
         return logs
 
-class EthGetLogsCache():
 
-    logs: Dict[str, EthGetLogsCachedValue]
+class EthGetLogsCache:
+
+    logs: Dict[int, EthGetLogsCachedValue]
 
     def __init__(self, web3):
         self.logs = {}
         self.web3 = web3
 
-    def get_next_batch_end(self, current_batch_start: int, final_block_number, batch_size=GET_LOGS_BATCH_SIZE):
+    @staticmethod
+    def get_next_batch_end(current_batch_start: int, final_block_number, batch_size=GET_LOGS_BATCH_SIZE):
         current_batch_end = current_batch_start + batch_size
         return min(current_batch_end, final_block_number)
 
     def get_logs(self, filter_params):
-
         from_block = filter_params["fromBlock"]
         to_block = filter_params["toBlock"]
-
         batch_size = filter_params["batchSize"] if "batchSize" in filter_params else GET_LOGS_BATCH_SIZE
         retries = filter_params["retries"] if "retries" in filter_params else GET_LOGS_MAX_RETRIES
-
         if "batchSize" in filter_params:
             del filter_params["batchSize"]
-
         if "retries" in filter_params:
             del filter_params["retries"]
-
-        address = filter_params["address"] if "address" in filter_params else ""
-        topics = filter_params["topics"] if "topics" in filter_params else ""
-
         current_batch_start = int(from_block)
-        current_batch_end = self.get_next_batch_end(current_batch_start, to_block, batch_size)
-
+        current_batch_end = EthGetLogsCache.get_next_batch_end(current_batch_start, to_block, batch_size)
         logs = list()
-
         while current_batch_start < current_batch_end:
             filter_params["fromBlock"] = current_batch_start
             filter_params["toBlock"] = current_batch_end
@@ -127,15 +120,15 @@ class EthGetLogsCache():
             for currentTry in range(1, (retries + 1)):
                 try:
                     logger.debug(f'Trying to get logs with params {filter_params} '
-                          f'from block {current_batch_start} to block {current_batch_end}. '
-                          f'(attempt {currentTry})')
+                                 f'from block {current_batch_start} to block {current_batch_end}. '
+                                 f'(attempt {currentTry})')
                     log_list = self.web3.manager.request_blocking(
                         "eth_getLogs", [filter_params],
                     )
                     break
                 except ValueError as e:
                     logger.warning(f'Error trying to get logs with params {filter_params} '
-                          f'from block {current_batch_start} to block {current_batch_end}', e)
+                                   f'from block {current_batch_start} to block {current_batch_end}', e)
             if log_list is None:
                 raise ValueError(f'Error trying to get logs with params {filter_params} '
                                  f'from block {current_batch_start} to block {current_batch_end}')
@@ -143,16 +136,15 @@ class EthGetLogsCache():
                 for log in log_list:
                     logs.append(log)
                 current_batch_start = current_batch_end + 1
-                current_batch_end = self.get_next_batch_end(current_batch_start, to_block, batch_size)
+                current_batch_end = EthGetLogsCache.get_next_batch_end(current_batch_start, to_block, batch_size)
 
         return logs
 
-
-
-    def generate_cache_key(self, address, topics) -> str:
+    @staticmethod
+    def generate_cache_key(address, topics) -> int:
         return hash(f"logs_{address}_{topics}")
 
-    def get(self, filter_params, earliest_block_number, latest_block_number) -> EthGetLogsCachedValue:
+    def get(self, filter_params, earliest_block_number, latest_block_number) -> list:
         from_block = filter_params["fromBlock"] if "fromBlock" in filter_params else earliest_block_number
         to_block = filter_params["toBlock"] if "toBlock" in filter_params else latest_block_number
         address = filter_params["address"] if "address" in filter_params else ""
@@ -192,6 +184,7 @@ class EthGetLogsCache():
             cached_value = EthGetLogsCachedValue(address, topics, earliest_block_number, latest_block_number, logs)
             self.logs[cache_key] = cached_value
             return cached_value.get_logs(from_block, to_block)
+
 
 class Eth(Module):
     account = Account()
@@ -498,7 +491,9 @@ class Eth(Module):
         )
 
     def getLogs(self, filter_params):
-        return self.logs_cache.get(filter_params, self.getBlock('earliest')["number"], self.getBlock('latest')["number"])
+        return self.logs_cache.get(filter_params,
+                                   self.getBlock('earliest')["number"],
+                                   self.getBlock('latest')["number"])
 
     def uninstallFilter(self, filter_id):
         return self.web3.manager.request_blocking(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -51,12 +51,138 @@ from web3.utils.transactions import (
     wait_for_transaction_receipt,
 )
 
-# 10000 blocks
-GET_LOGS_BATCH_SIZE: int = 10000
+from typing import Dict
+
+# 300000 blocks
+GET_LOGS_BATCH_SIZE: int = 300000
 
 GET_LOGS_MAX_RETRIES: int = 5
 
+# cache timeout in ms
+CACHE_TIMEOUT: int = 60000
+
+
+
 logger = logging.getLogger(__name__)
+
+class EthGetLogsCachedValue():
+
+    def __init__(self, address, topics, from_block, to_block, logs):
+        self.address = address
+        self.topics = topics
+        self.from_block = from_block
+        self.to_block = to_block
+        self.logs = logs
+
+    def get_logs(self, from_block, to_block):
+        logs = list()
+        for log in self.logs:
+            print(f">>>>>>>>>>>>>>>>. log {log}")
+            # TODO: fix the log search because is not working properly, always returns empty list
+            log_block_number = int(str(log["blockNumber"]), 16)
+            if log_block_number >= from_block and log_block_number <= to_block:
+                logs.append(log)
+        print(f"returning cached logs from {from_block} to {to_block}", logs)
+        return logs
+
+class EthGetLogsCache():
+
+    logs: Dict[str, EthGetLogsCachedValue]
+
+    def __init__(self, web3):
+        self.logs = {}
+        self.web3 = web3
+
+    def get_next_batch_end(self, current_batch_start: int, final_block_number, batch_size=GET_LOGS_BATCH_SIZE):
+        current_batch_end = current_batch_start + batch_size
+        return min(current_batch_end, final_block_number)
+
+    def get_logs(self, filter_params):
+
+        from_block = filter_params["fromBlock"]
+        to_block = filter_params["toBlock"]
+
+        batch_size = filter_params["batchSize"] if "batchSize" in filter_params else GET_LOGS_BATCH_SIZE
+        retries = filter_params["retries"] if "retries" in filter_params else GET_LOGS_MAX_RETRIES
+
+        address = filter_params["address"] if "address" in filter_params else ""
+        topics = filter_params["topics"] if "topics" in filter_params else ""
+
+        current_batch_start = int(from_block)
+        current_batch_end = self.get_next_batch_end(current_batch_start, to_block, batch_size)
+
+        logs = list()
+
+        while current_batch_start < current_batch_end:
+            filter_params["fromBlock"] = current_batch_start
+            filter_params["toBlock"] = current_batch_end
+            log_list = None
+            for currentTry in range(1, (retries + 1)):
+                try:
+                    print(f'Trying to get logs with params {filter_params} '
+                          f'from block {current_batch_start} to block {current_batch_end}. '
+                          f'(attempt {currentTry})')
+                    log_list = self.web3.manager.request_blocking(
+                        "eth_getLogs", [filter_params],
+                    )
+                    break
+                except ValueError as e:
+                    print(f'Error trying to get logs with params {filter_params} '
+                          f'from block {current_batch_start} to block {current_batch_end}', e)
+            if log_list is None:
+                raise ValueError(f'Error trying to get logs with params {filter_params} '
+                                 f'from block {current_batch_start} to block {current_batch_end}')
+            else:
+                for log in log_list:
+                    logs.append(log)
+                current_batch_start = current_batch_end + 1
+                current_batch_end = self.get_next_batch_end(current_batch_start, to_block, batch_size)
+
+        return logs
+
+
+
+    def generate_cache_key(self, address, topics) -> str:
+        return hash(f"logs_{address}_{topics}")
+
+    def get(self, filter_params, earliest_block_number, latest_block_number) -> EthGetLogsCachedValue:
+        from_block = filter_params["fromBlock"] if "batchSize" in filter_params else earliest_block_number
+        to_block = filter_params["toBlock"] if "batchSize" in filter_params else latest_block_number
+        address = filter_params["address"] if "address" in filter_params else ""
+        topics = filter_params["topics"] if "topics" in filter_params else ""
+        invalidate_cache = filter_params["invalidate_cache"] if "invalidate_cache" in filter_params else False
+        # check the cache before populating with data
+        cache_key = self.generate_cache_key(address, topics)
+        print(f"getting logs with cache key {cache_key}")
+        if cache_key in self.logs and not invalidate_cache:
+            print(f"cache exists and is not being ivalidated")
+            # here we have all the logs from earliest to latest on the last iteration
+            # we need to check if the current iteration doesn't need an update from
+            # latest of last iteration to current block
+            cached_value: EthGetLogsCachedValue = self.logs[cache_key]
+            # we need to leave at least 50 confirmation blocks for reorgs
+            cache_to_block = latest_block_number - 50
+            if cached_value.to_block < cache_to_block:
+                print(f"cache needs update from {cached_value.to_block} to {cache_to_block}")
+                # we need to update this cache from the current to_block to the new cache_to_block
+                filter_params["fromBlock"] = cached_value.to_block
+                filter_params["toBlock"] = cache_to_block
+                logs = self.get_logs(filter_params)
+                cached_value.logs.append(logs)
+                cached_value.to_block = cache_to_block
+                print(f"updated cache")
+            return cached_value.get_logs(from_block, to_block)
+
+        else:
+            print(f"cache doesn't exists or is being invalidated")
+            # retrieve all logs from earliest to latest to populate cache
+            filter_params["fromBlock"] = earliest_block_number
+            filter_params["toBlock"] = latest_block_number
+            logs = self.get_logs(filter_params)
+            print(f"generating and saving cached value logs {logs}")
+            cached_value = EthGetLogsCachedValue(address, topics, earliest_block_number, latest_block_number, logs)
+            self.logs[cache_key] = cached_value
+            return cached_value.get_logs(from_block, to_block)
 
 class Eth(Module):
     account = Account()
@@ -65,6 +191,11 @@ class Eth(Module):
     defaultContractFactory = Contract
     iban = Iban
     gasPriceStrategy = None
+    logs_cache: EthGetLogsCache
+
+    def __init__(self, web3):
+        super().__init__(web3)
+        self.logs_cache = EthGetLogsCache(web3)
 
     @deprecated_for("doing nothing at all")
     def enable_unaudited_features(self):
@@ -358,45 +489,7 @@ class Eth(Module):
         )
 
     def getLogs(self, filter_params):
-        from_block = filter_params["fromBlock"] if "batchSize" in filter_params else self.getBlock("earliest")["number"]
-        to_block = filter_params["toBlock"] if "batchSize" in filter_params else self.getBlock("latest")["number"]
-        batch_size = filter_params["batchSize"] if "batchSize" in filter_params else GET_LOGS_BATCH_SIZE
-        retries = filter_params["retries"] if "retries" in filter_params else GET_LOGS_MAX_RETRIES
-
-        current_batch_start = int(from_block)
-        current_batch_end = self.get_next_batch_end(current_batch_start, to_block, batch_size)
-
-        logs = list()
-
-        while current_batch_start < current_batch_end:
-            filter_params["fromBlock"] = current_batch_start
-            filter_params["toBlock"] = current_batch_end
-            log_list = None
-            for currentTry in range(0, retries):
-                try:
-                    logger.debug(f'Trying to get logs with params {filter_params} '
-                                 f'from block {current_batch_start} to block {current_batch_end}. (attempt {currentTry})')
-                    log_list = self.web3.manager.request_blocking(
-                        "eth_getLogs", [filter_params],
-                    )
-                    break
-                except ValueError as e:
-                    logger.warning(f'Error trying to get logs with params {filter_params} '
-                                   f'from block {current_batch_start} to block {current_batch_end}', e)
-            if log_list is None:
-                raise ValueError(f'Error trying to get logs with params {filter_params} '
-                                 f'from block {current_batch_start} to block {current_batch_end}')
-            else:
-                for log in log_list:
-                    logs.append(log)
-                current_batch_start = current_batch_end + 1
-                current_batch_end = self.get_next_batch_end(current_batch_start, to_block, batch_size)
-
-        return logs
-
-    def get_next_batch_end(self, current_batch_start: int, final_block_number, batch_size=GET_LOGS_BATCH_SIZE):
-        current_batch_end = current_batch_start + batch_size
-        return min(current_batch_end, final_block_number)
+        return self.logs_cache.get(filter_params, self.getBlock('earliest')["number"], self.getBlock('latest')["number"])
 
     def uninstallFilter(self, filter_id):
         return self.web3.manager.request_blocking(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -74,7 +74,7 @@ class EthGetLogsCachedValue:
                  topics: List[str],
                  from_block: int,
                  to_block: int,
-                 logs: List[Dict]):
+                 logs: List[dict]):
         self.address = address
         self.topics = topics
         self.from_block = from_block

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -350,6 +350,9 @@ class Eth(Module):
         )
 
     def getLogs(self, filter_params):
+        fb = filter_params["fromBlock"]
+        filter_params["fromBlock"] = max(1400000, fb)
+        print(f"web3.py >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> executing get logs from block {filter_params['fromBlock']}")
         return self.web3.manager.request_blocking(
             "eth_getLogs", [filter_params],
         )

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -361,8 +361,8 @@ class Eth(Module):
         )
 
     def getLogs(self, filter_params):
-        from_block = filter_params["fromBlock"] if "batchSize" in filter_params else self.getBlock('earliest')
-        to_block = filter_params["toBlock"] if "batchSize" in filter_params else self.getBlock('latest')
+        from_block = filter_params["fromBlock"] if "batchSize" in filter_params else self.getBlock("earliest")["number"]
+        to_block = filter_params["toBlock"] if "batchSize" in filter_params else self.getBlock("latest")["number"]
         batch_size = filter_params["batchSize"] if "batchSize" in filter_params else GET_LOGS_BATCH_SIZE
         wait_for_request = \
             filter_params["waitForRequest"] if "waitForRequest" in filter_params else GET_LOGS_MAX_WAIT_FOR_REQUEST

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -1,5 +1,3 @@
-import logging
-
 from eth_account import (
     Account,
 )
@@ -18,6 +16,7 @@ from web3.contract import (
 from web3.iban import (
     Iban,
 )
+from web3.logs_manager import EthLogsManager
 from web3.module import (
     Module,
 )
@@ -51,147 +50,6 @@ from web3.utils.transactions import (
     wait_for_transaction_receipt,
 )
 
-from typing import Dict, List, Any
-
-# 300000 blocks
-GET_LOGS_BATCH_SIZE: int = 300000
-
-GET_LOGS_MAX_RETRIES: int = 5
-
-# cache timeout in ms
-CACHE_TIMEOUT: int = 60000
-
-# 50 blocks
-CONFIRMATION_BLOCKS: int = 50
-
-logger = logging.getLogger(__name__)
-
-
-class EthGetLogsCachedValue:
-
-    def __init__(self,
-                 address: str,
-                 topics: List[str],
-                 from_block: int,
-                 to_block: int,
-                 logs: List[dict]):
-        self.address = address
-        self.topics = topics
-        self.from_block = from_block
-        self.to_block = to_block
-        self.logs = logs
-
-    def get_logs(self, from_block: int, to_block: int):
-        logs = list()
-        for log in self.logs:
-            # this is needed since rskj sometimes provide events without blockNumber
-            # (that's something that sometimes happens but not always, seems to be a bug on the core)
-            log_block_number: int = log['blockNumber'] if "blockNumber" in log else None
-            if log_block_number and from_block <= log_block_number <= to_block:
-                logs.append(log)
-        logger.debug(f"Getting logs from cached value from block {from_block} to block {to_block} -> logs {logs}")
-        return logs
-
-
-class EthGetLogsCache:
-
-    logs: Dict[int, EthGetLogsCachedValue]
-
-    def __init__(self, web3):
-        self.logs = {}
-        self.web3 = web3
-
-    @staticmethod
-    def get_next_batch_end(current_batch_start: int,
-                           final_block_number: int,
-                           batch_size: int = GET_LOGS_BATCH_SIZE) -> int:
-        current_batch_end = current_batch_start + batch_size
-        return min(current_batch_end, final_block_number)
-
-    def get_logs(self, filter_params):
-        from_block: int = filter_params["fromBlock"]
-        to_block: int = filter_params["toBlock"]
-        batch_size: int = filter_params["batchSize"] if "batchSize" in filter_params else GET_LOGS_BATCH_SIZE
-        retries: int = filter_params["retries"] if "retries" in filter_params else GET_LOGS_MAX_RETRIES
-        if "batchSize" in filter_params:
-            del filter_params["batchSize"]
-        if "retries" in filter_params:
-            del filter_params["retries"]
-        current_batch_start: int = int(from_block)
-        current_batch_end: int = EthGetLogsCache.get_next_batch_end(current_batch_start, to_block, batch_size)
-        logs = list()
-        while current_batch_start < current_batch_end:
-            filter_params["fromBlock"] = current_batch_start
-            filter_params["toBlock"] = current_batch_end
-            log_list = None
-            for currentTry in range(1, (retries + 1)):
-                try:
-                    logger.debug(f'Trying to get logs with params {filter_params} '
-                                 f'from block {current_batch_start} to block {current_batch_end}. '
-                                 f'(attempt {currentTry})')
-                    log_list = self.web3.manager.request_blocking(
-                        "eth_getLogs", [filter_params],
-                    )
-                    break
-                except ValueError as e:
-                    logger.warning(f'Error trying to get logs with params {filter_params} '
-                                   f'from block {current_batch_start} to block {current_batch_end}', e)
-            if log_list is None:
-                raise ValueError(f'Error trying to get logs with params {filter_params} '
-                                 f'from block {current_batch_start} to block {current_batch_end}')
-            else:
-                for log in log_list:
-                    logs.append(log)
-                current_batch_start = current_batch_end + 1
-                current_batch_end = EthGetLogsCache.get_next_batch_end(current_batch_start, to_block, batch_size)
-
-        return logs
-
-    @staticmethod
-    def generate_cache_key(address: str, topics: List[str]) -> int:
-        return hash(f"logs_{address}_{topics}")
-
-    def get(self, filter_params: Any, earliest_block_number: int, latest_block_number: int) -> List:
-        from_block: int = filter_params["fromBlock"] if "fromBlock" in filter_params else earliest_block_number
-        to_block: int = filter_params["toBlock"] if "toBlock" in filter_params else latest_block_number
-        address: str = filter_params["address"] if "address" in filter_params else ""
-        topics: List[str] = filter_params["topics"] if "topics" in filter_params else ""
-        invalidate_cache: bool = filter_params["invalidate_cache"] if "invalidate_cache" in filter_params else False
-        if "invalidate_cache" in filter_params:
-            del filter_params["invalidate_cache"]
-        # check the cache before populating with data
-        cache_key: int = self.generate_cache_key(address, topics)
-        logger.debug(f"getting logs with cache key {cache_key}")
-        if cache_key in self.logs and not invalidate_cache:
-            logger.debug(f"cache exists and is not being invalidated")
-            # here we have all the logs from earliest to latest on the last iteration
-            # we need to check if the current iteration doesn't need an update from
-            # latest of last iteration to current block
-            cached_value: EthGetLogsCachedValue = self.logs[cache_key]
-            # we need to leave at least a number of confirmation blocks for reorgs
-            cache_to_block: int = latest_block_number - CONFIRMATION_BLOCKS
-            if cached_value.to_block < cache_to_block:
-                logger.debug(f"cache needs update from {cached_value.to_block} to {cache_to_block}")
-                # we need to update this cache from the current to_block to the new cache_to_block
-                filter_params["fromBlock"] = cached_value.to_block
-                filter_params["toBlock"] = cache_to_block
-                logs = self.get_logs(filter_params)
-                cached_value.logs.append(logs)
-                cached_value.to_block = cache_to_block
-                logger.debug(f"updated cache")
-            return cached_value.get_logs(from_block, to_block)
-
-        else:
-            logger.debug(f"cache doesn't exists or is being invalidated")
-            # retrieve all logs from earliest to latest to populate cache
-            filter_params["fromBlock"] = earliest_block_number
-            filter_params["toBlock"] = latest_block_number
-            logs = self.get_logs(filter_params)
-            logger.debug(f"generating and saving cached value logs {logs}")
-            cached_value = EthGetLogsCachedValue(address, topics, earliest_block_number, latest_block_number, logs)
-            self.logs[cache_key] = cached_value
-            return cached_value.get_logs(from_block, to_block)
-
 
 class Eth(Module):
     account = Account()
@@ -200,11 +58,11 @@ class Eth(Module):
     defaultContractFactory = Contract
     iban = Iban
     gasPriceStrategy = None
-    logs_cache: EthGetLogsCache
+    logs_manager: EthLogsManager
 
     def __init__(self, web3):
         super().__init__(web3)
-        self.logs_cache = EthGetLogsCache(web3)
+        self.logs_cache = EthLogsManager(web3)
 
     @deprecated_for("doing nothing at all")
     def enable_unaudited_features(self):
@@ -498,9 +356,11 @@ class Eth(Module):
         )
 
     def getLogs(self, filter_params):
-        return self.logs_cache.get(filter_params,
-                                   self.getBlock('earliest')["number"],
-                                   self.getBlock('latest')["number"])
+        return self.logs_manager.get_logs(
+            filter_params,
+            self.getBlock('earliest')["number"],
+            self.getBlock('latest')["number"]
+        )
 
     def uninstallFilter(self, filter_id):
         return self.web3.manager.request_blocking(

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -163,7 +163,7 @@ class EthGetLogsCache:
         cache_key: int = self.generate_cache_key(address, topics)
         logger.debug(f"getting logs with cache key {cache_key}")
         if cache_key in self.logs and not invalidate_cache:
-            logger.debug(f"cache exists and is not being ivalidated")
+            logger.debug(f"cache exists and is not being invalidated")
             # here we have all the logs from earliest to latest on the last iteration
             # we need to check if the current iteration doesn't need an update from
             # latest of last iteration to current block

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -74,7 +74,7 @@ class EthGetLogsCachedValue:
                  topics: List[str],
                  from_block: int,
                  to_block: int,
-                 logs: List):
+                 logs: List[Dict]):
         self.address = address
         self.topics = topics
         self.from_block = from_block

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -361,12 +361,12 @@ class Eth(Module):
         )
 
     def getLogs(self, filter_params):
-        from_block = filter_params["fromBlock"]
-        to_block = filter_params["toBlock"]
-        batch_size = filter_params["batchSize"] if filter_params["batchSize"] else GET_LOGS_BATCH_SIZE
+        from_block = filter_params["fromBlock"] if "batchSize" in filter_params else self.getBlock('earliest')
+        to_block = filter_params["toBlock"] if "batchSize" in filter_params else self.getBlock('latest')
+        batch_size = filter_params["batchSize"] if "batchSize" in filter_params else GET_LOGS_BATCH_SIZE
         wait_for_request = \
-            filter_params["waitForRequest"] if filter_params["waitForRequest"] else GET_LOGS_MAX_WAIT_FOR_REQUEST
-        retries = filter_params["retries"] if filter_params["retries"] else GET_LOGS_MAX_RETRIES
+            filter_params["waitForRequest"] if "waitForRequest" in filter_params else GET_LOGS_MAX_WAIT_FOR_REQUEST
+        retries = filter_params["retries"] if "retries" in filter_params else GET_LOGS_MAX_RETRIES
 
         current_batch_start = int(from_block)
         current_batch_end = self.get_next_batch_end(current_batch_start, to_block, batch_size)

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -352,7 +352,6 @@ class Eth(Module):
     def getLogs(self, filter_params):
         fb = filter_params["fromBlock"]
         filter_params["fromBlock"] = max(1400000, fb)
-        print(f"web3.py >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> executing get logs from block {filter_params['fromBlock']}")
         return self.web3.manager.request_blocking(
             "eth_getLogs", [filter_params],
         )

--- a/web3/logs_manager.py
+++ b/web3/logs_manager.py
@@ -10,10 +10,6 @@ GET_LOGS_BATCH_SIZE: int = 300000  # 300000 blocks
 
 GET_LOGS_MAX_RETRIES: int = 5
 
-CACHE_TIMEOUT: int = 60000  # in ms
-
-CONFIRMATION_BLOCKS: int = 50  # 50 blocks
-
 
 class EthLogsManager:
 

--- a/web3/logs_manager.py
+++ b/web3/logs_manager.py
@@ -14,7 +14,6 @@ GET_LOGS_MAX_RETRIES: int = 5
 class EthLogsManager:
 
     def __init__(self, web3):
-        self.logs: Dict[int, EthLogsCacheEntry] = {}
         self.web3 = web3
 
     @staticmethod

--- a/web3/logs_manager.py
+++ b/web3/logs_manager.py
@@ -1,0 +1,88 @@
+import logging
+
+from typing import List, Dict, Any
+
+from web3.logs_entry import EthLogsCacheEntry
+
+logger = logging.getLogger(__name__)
+
+GET_LOGS_BATCH_SIZE: int = 300000  # 300000 blocks
+
+GET_LOGS_MAX_RETRIES: int = 5
+
+CACHE_TIMEOUT: int = 60000  # in ms
+
+CONFIRMATION_BLOCKS: int = 50  # 50 blocks
+
+
+class EthLogsManager:
+
+    def __init__(self, web3):
+        self.logs: Dict[int, EthLogsCacheEntry] = {}
+        self.web3 = web3
+
+    @staticmethod
+    def get_next_batch_end(current_batch_start: int,
+                           final_block_number: int,
+                           batch_size: int = GET_LOGS_BATCH_SIZE) -> int:
+        current_batch_end = current_batch_start + batch_size
+        return min(current_batch_end, final_block_number)
+
+    def get_logs(self, filter_params: Dict, earliest_block_number: int, latest_block_number: int) -> List[dict]:
+        from_block = EthLogsManager.block_identifier_to_number(
+            filter_params.get("fromBlock", earliest_block_number),
+            earliest_block_number,
+            latest_block_number)
+        to_block = EthLogsManager.block_identifier_to_number(
+            filter_params.get("toBlock", latest_block_number),
+            earliest_block_number,
+            latest_block_number)
+        batch_size = filter_params.get("batchSize", GET_LOGS_BATCH_SIZE)
+        retries = filter_params.get("retries", GET_LOGS_MAX_RETRIES)
+
+        # remove superflous keys for eventual manager request call
+        filter_params.pop("batchSize", None)
+        filter_params.pop("retries", None)
+
+        current_batch_start: int = int(from_block)
+        current_batch_end: int = EthLogsManager.get_next_batch_end(current_batch_start, to_block, batch_size)
+        logs = []
+        while current_batch_start < current_batch_end:
+            filter_params["fromBlock"] = current_batch_start
+            filter_params["toBlock"] = current_batch_end
+            log_list = None
+            for currentTry in range(retries):
+                try:
+                    logger.debug(f'Trying to get logs with params {filter_params} '
+                                 f'from block {current_batch_start} to block {current_batch_end}. '
+                                 f'(attempt {currentTry + 1})')
+                    log_list = self.web3.manager.request_blocking(
+                        "eth_getLogs", [filter_params],
+                    )
+                    break
+                except ValueError as e:
+                    logger.warning(f'Error trying to get logs with params {filter_params} '
+                                   f'from block {current_batch_start} to block {current_batch_end}', e)
+            if log_list is None:
+                raise ValueError(f'Error trying to get logs with params {filter_params} '
+                                 f'from block {current_batch_start} to block {current_batch_end}')
+            else:
+                for log in log_list:
+                    logs.append(log)
+                current_batch_start = current_batch_end + 1
+                current_batch_end = EthLogsManager.get_next_batch_end(current_batch_start, to_block, batch_size)
+
+        return logs
+
+    @staticmethod
+    def generate_cache_key(address: str, topics: List[str]) -> int:
+        return hash(f"logs_{address}_{topics.sort()}")
+
+    @staticmethod
+    def block_identifier_to_number(block_identifier: Any, earliest_block_number: int, latest_block_number: int) -> int:
+        if str(block_identifier) == "latest":
+            return latest_block_number
+        elif str(block_identifier) == "earliest":
+            return earliest_block_number
+        else:
+            return block_identifier

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -113,12 +113,12 @@ class RequestManager:
 
         return response['result']
 
-    def request_async(self, method, params):
+    def request_async(self, raw_method, raw_params):
         request_id = uuid.uuid4()
         self.pending_requests[request_id] = spawn(
             self.request_blocking,
-            method,
-            params,
+            raw_method=raw_method,
+            raw_params=raw_params,
         )
         return request_id
 

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -113,12 +113,12 @@ class RequestManager:
 
         return response['result']
 
-    def request_async(self, raw_method, raw_params):
+    def request_async(self, method, params):
         request_id = uuid.uuid4()
         self.pending_requests[request_id] = spawn(
             self.request_blocking,
-            raw_method=raw_method,
-            raw_params=raw_params,
+            method,
+            params,
         )
         return request_id
 


### PR DESCRIPTION
### What was wrong?

RSK doesn't allow `eth_getLogs` calls with a big block size number. The fromBlock and toBlock params have to be near because the RSKj node doesn't suppport big queries.

### How was it fixed?

To fix this we added support to make small batch queries instead of making a huge one. Also we added some cache to store the logs to avoid having to query them all the time.
